### PR TITLE
Enable Style/StringLiterals and set it to double quotes

### DIFF
--- a/config/chefstyle.yml
+++ b/config/chefstyle.yml
@@ -124,3 +124,6 @@ Style/SpaceInsideBrackets:
 Style/SpaceInsideParens:
   Enabled: false
 
+Style/StringLiterals:
+  EnforcedStyle: double_quotes
+  Enabled: true


### PR DESCRIPTION
cc @chef/client-maintainers

We mix single quotes and double quotes all the time in files, and it's really annoying to try and match what the rest of the file does.
There's no performance cost to just using double quotes across the board, and it makes life better.