### PR TITLE
add rule for Style/PercentLiteralDelimiters

### DIFF
--- a/config/chefstyle.yml
+++ b/config/chefstyle.yml
@@ -105,6 +105,7 @@ Metrics/PerceivedComplexity:
 # - The old 1.9 pickaxe book does not use %i
 # - %s is not used in chef code or the pickaxe book, and is %s{} for consistency
 Style/PercentLiteralDelimiters:
+  Enabled: true
   PreferredDelimiters:
     '%':  '{}'
     '%i': '{}'

--- a/config/chefstyle.yml
+++ b/config/chefstyle.yml
@@ -99,6 +99,22 @@ Metrics/PerceivedComplexity:
 # Style
 #
 
+# - The chef source code predominantly uses {} for %,%i,%q,%Q,%r,%w,%W
+# - The old 1.9 pickaxe book predominantly uses {} for %,%q,%Q,%r,%w,%W,%x
+# - The chef source code does not use %x enough to determine a preference
+# - The old 1.9 pickaxe book does not use %i
+# - %s is not used in chef code or the pickaxe book, and is %s{} for consistency
+Style/PercentLiteralDelimiters:
+  PreferredDelimiters:
+    '%':  '{}'
+    '%i': '{}'
+    '%q': '{}'
+    '%Q': '{}'
+    '%r': '{}'
+    '%s': '{}'
+    '%w': '{}'
+    '%W': '{}'
+    '%x': '{}'
 # we only 'raise' and do not 'fail'
 Style/SignalException:
   EnforcedStyle: only_raise


### PR DESCRIPTION
I grepped the source code looking for actual usage and went through
the old ruby 1.9 pickaxe PDF and the result is that '{}' is how we
actually have written the chef source code and its what all the old
farts actually learned.

e.g.

```
% egrep -rI "%w" . | sed -e 's/.*%w/%w/' | cut -c 1-3 | sort | uniq -c | sort -rn
 164 %w{
 100 %w(
  54 %w[
   1 %w|
```

I vote the old ways are best and there's no reason to change this.

And if you go back to chef 11.0.0 its gets somewhat more lopsided towards '{}':

```
% egrep -rI "%w" . | sed -e 's/.*%w/%w/' | cut -c 1-3 | sort | uniq -c | sort -rn
 120 %w{
  30 %w[
  23 %w(
   1 %w|
```