### PR TITLE
fixes for 0.37.2

### DIFF
--- a/config/chefstyle.yml
+++ b/config/chefstyle.yml
@@ -1,4 +1,3 @@
-
 #
 # Lint
 #
@@ -101,8 +100,6 @@ Performance/Size:
 Rails/ActionFilter:
   Enabled: true
 Rails/Date:
-  Enabled: true
-Rails/DefaultScope:
   Enabled: true
 Rails/Delegate:
   Enabled: true
@@ -265,7 +262,7 @@ Style/SpaceBeforeBlockBraces:
   Enabled: true
 Style/SpaceBeforeFirstArg:
   Enabled: true
-Style/SpaceBeforeModifierKeyword:
+Style/SpaceAroundKeyword:
   Enabled: true
 Style/SpaceInsideBlockBraces:
   Enabled: true
@@ -286,7 +283,10 @@ Style/Tab:
 Style/TrailingBlankLines:
   Enabled: true
 # rubocop's default gets this completely backwards
-Style/TrailingComma:
+Style/TrailingCommaInLiteral:
+  Enabled: true
+  EnforcedStyleForMultiline: comma
+Style/TrailingCommaInArguments:
   Enabled: true
   EnforcedStyleForMultiline: comma
 Style/TrailingUnderscoreVariable:
@@ -314,7 +314,7 @@ Style/Documentation:
   Enabled: false
 
 # this makes whitespace formatting of DSL code impossible
-Style/SingleSpaceBeforeFirstArg:
+Style/SpaceBeforeFirstArg:
   Enabled: false
 
 # whitespace in expressions is useful to enhance readability

--- a/config/chefstyle.yml
+++ b/config/chefstyle.yml
@@ -282,11 +282,10 @@ Style/Tab:
   Enabled: true
 Style/TrailingBlankLines:
   Enabled: true
+Style/TrailingCommaInArguments:
+  Enabled: true
 # rubocop's default gets this completely backwards
 Style/TrailingCommaInLiteral:
-  Enabled: true
-  EnforcedStyleForMultiline: comma
-Style/TrailingCommaInArguments:
   Enabled: true
   EnforcedStyleForMultiline: comma
 Style/TrailingUnderscoreVariable:


### PR DESCRIPTION
for some reason chefstyle doesn't complain about these, but if i run
rubocop it gets pissed about deprecated/renamed configs.

may need to make chefstyle more strict about config file parsing.