### PR TITLE
add BlockDelimiters and MultilineBlockLayout and bump engine to 0.42.0

### DIFF
--- a/config/chefstyle.yml
+++ b/config/chefstyle.yml
@@ -216,6 +216,8 @@ Style/Attr:
   Enabled: true
 Style/BeginBlock:
   Enabled: true
+Style/BlockDelimiters:
+  Enabled: true
 Style/CharacterLiteral:
   Enabled: true
 Style/ClassMethods:
@@ -267,6 +269,8 @@ Style/InitialIndentation:
 Style/LambdaCall:
   Enabled: true
 Style/MethodDefParentheses:
+  Enabled: true
+Style/MultilineBlockLayout:
   Enabled: true
 Style/MultilineIfThen:
   Enabled: true

--- a/config/disable_all.yml
+++ b/config/disable_all.yml
@@ -45,6 +45,8 @@ Lint/HandleExceptions:
   Enabled: false
 Lint/ImplicitStringConcatenation:
   Enabled: false
+Lint/InheritException:
+  Enabled: false
 Lint/IneffectiveAccessModifier:
   Enabled: false
 Lint/InvalidCharacterLiteral:
@@ -63,11 +65,17 @@ Lint/NonLocalExitFromIterator:
   Enabled: false
 Lint/ParenthesesAsGroupedExpression:
   Enabled: false
+Lint/PercentStringArray:
+  Enabled: false
+Lint/PercentSymbolArray:
+  Enabled: false
 Lint/RandOne:
   Enabled: false
 Lint/RequireParentheses:
   Enabled: false
 Lint/RescueException:
+  Enabled: false
+Lint/ShadowedException:
   Enabled: false
 Lint/ShadowingOuterLocalVariable:
   Enabled: false
@@ -84,6 +92,8 @@ Lint/UnusedBlockArgument:
 Lint/UnusedMethodArgument:
   Enabled: false
 Lint/UselessAccessModifier:
+  Enabled: false
+Lint/UselessArraySplat:
   Enabled: false
 Lint/UselessAssignment:
   Enabled: false
@@ -132,6 +142,8 @@ Performance/FlatMap:
 Performance/HashEachMethods:
   Enabled: false
 Performance/LstripRstrip:
+  Enabled: false
+Performance/PushSplat:
   Enabled: false
 Performance/RangeInclude:
   Enabled: false
@@ -227,7 +239,7 @@ Style/Copyright:
   Enabled: false
 Style/DefWithParentheses:
   Enabled: false
-Style/DeprecatedHashMethods:
+Style/PreferredHashMethods:
   Enabled: false
 Style/Documentation:
   Enabled: false
@@ -235,9 +247,13 @@ Style/DotPosition:
   Enabled: false
 Style/DoubleNegation:
   Enabled: false
+Style/EachForSimpleLoop:
+  Enabled: false
 Style/EachWithObject:
   Enabled: false
 Style/ElseAlignment:
+  Enabled: false
+Style/EmptyCaseCondition:
   Enabled: false
 Style/EmptyElse:
   Enabled: false
@@ -303,6 +319,8 @@ Style/IfUnlessModifierOfIfUnless:
   Enabled: false
 Style/IfWithSemicolon:
   Enabled: false
+Style/ImplicitRuntimeError:
+  Enabled: false
 Style/IndentArray:
   Enabled: false
 Style/IndentAssignment:
@@ -334,6 +352,8 @@ Style/MethodCalledOnDoEndBlock:
 Style/MethodDefParentheses:
   Enabled: false
 Style/MethodName:
+  Enabled: false
+Style/MethodMissing:
   Enabled: false
 Style/MissingElse:
   Enabled: false
@@ -382,6 +402,10 @@ Style/NonNilCheck:
 Style/Not:
   Enabled: false
 Style/NumericLiterals:
+  Enabled: false
+Style/NumericLiteralPrefix:
+  Enabled: false
+Style/NumericPredicate:
   Enabled: false
 Style/OneLineConditional:
   Enabled: false
@@ -465,6 +489,8 @@ Style/SpaceBeforeFirstArg:
   Enabled: false
 Style/SpaceBeforeSemicolon:
   Enabled: false
+Style/SpaceInsideArrayPercentLiteral:
+  Enabled: false
 Style/SpaceInsideBlockBraces:
   Enabled: false
 Style/SpaceInsideBrackets:
@@ -472,6 +498,8 @@ Style/SpaceInsideBrackets:
 Style/SpaceInsideHashLiteralBraces:
   Enabled: false
 Style/SpaceInsideParens:
+  Enabled: false
+Style/SpaceInsidePercentLiteralDelimiters:
   Enabled: false
 Style/SpaceInsideRangeLiteral:
   Enabled: false
@@ -496,6 +524,8 @@ Style/SymbolLiteral:
 Style/SymbolProc:
   Enabled: false
 Style/Tab:
+  Enabled: false
+Style/TernaryParentheses:
   Enabled: false
 Style/TrailingBlankLines:
   Enabled: false
@@ -537,11 +567,15 @@ Rails/Date:
   Enabled: false
 Rails/Delegate:
   Enabled: false
+Rails/Exit:
+  Enabled: false
 Rails/FindBy:
   Enabled: false
 Rails/FindEach:
   Enabled: false
 Rails/HasAndBelongsToMany:
+  Enabled: false
+Rails/OutputSafety:
   Enabled: false
 Rails/Output:
   Enabled: false
@@ -549,9 +583,15 @@ Rails/PluralizationGrammar:
   Enabled: false
 Rails/ReadWriteAttribute:
   Enabled: false
+Rails/RequestReferer:
+  Enabled: false
+Rails/SaveBang:
+  Enabled: false
 Rails/ScopeArgs:
   Enabled: false
 Rails/TimeZone:
+  Enabled: false
+Rails/UniqBeforePluck:
   Enabled: false
 Rails/Validation:
   Enabled: false

--- a/config/disabled.yml
+++ b/config/disabled.yml
@@ -5,6 +5,11 @@
 Rails:
   Enabled: false
 
+Rails/SaveBang:
+  Description: 'Identifies possible cases where Active Record save! or related should be used.'
+  StyleGuide: 'https://github.com/bbatsov/rails-style-guide#save-bang'
+  Enabled: false
+
 Style/AutoResourceCleanup:
   Description: 'Suggests the usage of an auto resource cleanup version of a method (if available).'
   Enabled: false
@@ -47,6 +52,12 @@ Style/FirstMethodParameterLineBreak:
                  multi-line method parameter definition.
   Enabled: false
 
+Style/ImplicitRuntimeError:
+  Description: >-
+                 Use `raise` or `fail` with an explicit exception class and
+                 message, rather than just a message.
+  Enabled: false
+
 Style/InlineComment:
   Description: 'Avoid inline comments.'
   Enabled: false
@@ -73,37 +84,9 @@ Style/MissingElse:
     - case
     - both
 
-Style/MultilineArrayBraceLayout:
-  Description: >-
-                 Checks that the closing brace in an array literal is
-                 symmetrical with respect to the opening brace and the
-                 array elements.
-  Enabled: false
-
 Style/MultilineAssignmentLayout:
   Description: 'Check for a newline after the assignment operator in multi-line assignments.'
   StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#indent-conditional-assignment'
-  Enabled: false
-
-Style/MultilineHashBraceLayout:
-  Description: >-
-                 Checks that the closing brace in a hash literal is
-                 symmetrical with respect to the opening brace and the
-                 hash elements.
-  Enabled: false
-
-Style/MultilineMethodCallBraceLayout:
-  Description: >-
-                 Checks that the closing brace in a method call is
-                 symmetrical with respect to the opening brace and the
-                 method arguments.
-  Enabled: false
-
-Style/MultilineMethodDefinitionBraceLayout:
-  Description: >-
-                 Checks that the closing brace in a method definition is
-                 symmetrical with respect to the opening brace and the
-                 method parameters.
   Enabled: false
 
 Style/OptionHash:

--- a/config/enabled.yml
+++ b/config/enabled.yml
@@ -7,6 +7,7 @@ Style/AccessModifierIndentation:
 
 Style/AccessorMethodName:
   Description: Check the naming of accessor methods for get_/set_.
+  StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#accessor_mutator_method_names'
   Enabled: true
 
 Style/Alias:
@@ -170,8 +171,8 @@ Style/DefWithParentheses:
   StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#method-parens'
   Enabled: true
 
-Style/DeprecatedHashMethods:
-  Description: 'Checks for use of deprecated Hash methods.'
+Style/PreferredHashMethods:
+  Description: 'Checks use of `has_key?` and `has_value?` Hash methods.'
   StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#hash-key'
   Enabled: true
 
@@ -192,6 +193,12 @@ Style/DoubleNegation:
   StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#no-bang-bang'
   Enabled: true
 
+Style/EachForSimpleLoop:
+  Description: >-
+                 Use `Integer#times` for a simple loop which iterates a fixed
+                 number of times.
+  Enabled: true
+
 Style/EachWithObject:
   Description: 'Prefer `each_with_object` over `inject` or `reduce`.'
   Enabled: true
@@ -202,6 +209,10 @@ Style/ElseAlignment:
 
 Style/EmptyElse:
   Description: 'Avoid empty else-clauses.'
+  Enabled: true
+
+Style/EmptyCaseCondition:
+  Description: 'Avoid empty condition in case statements.'
   Enabled: true
 
 Style/EmptyLineBetweenDefs:
@@ -406,9 +417,21 @@ Style/MethodName:
   StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#snake-case-symbols-methods-vars'
   Enabled: true
 
+Style/MethodMissing:
+  Description: 'Avoid using `method_missing`.'
+  StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#no-method-missing'
+  Enabled: true
+
 Style/ModuleFunction:
   Description: 'Checks for usage of `extend self` in modules.'
   StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#module-function'
+  Enabled: true
+
+Style/MultilineArrayBraceLayout:
+  Description: >-
+                 Checks that the closing brace in an array literal is
+                 either on the same line as the last array element, or
+                 a new line.
   Enabled: true
 
 Style/MultilineBlockChain:
@@ -420,15 +443,36 @@ Style/MultilineBlockLayout:
   Description: 'Ensures newlines after multiline block do statements.'
   Enabled: true
 
+Style/MultilineHashBraceLayout:
+  Description: >-
+                 Checks that the closing brace in a hash literal is
+                 either on the same line as the last hash element, or
+                 a new line.
+  Enabled: true
+
 Style/MultilineIfThen:
   Description: 'Do not use then for multi-line if/unless.'
   StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#no-then'
+  Enabled: true
+
+Style/MultilineMethodCallBraceLayout:
+  Description: >-
+                 Checks that the closing brace in a method call is
+                 either on the same line as the last method argument, or
+                 a new line.
   Enabled: true
 
 Style/MultilineMethodCallIndentation:
   Description: >-
                  Checks indentation of method calls with the dot operator
                  that span more than one line.
+  Enabled: true
+
+Style/MultilineMethodDefinitionBraceLayout:
+  Description: >-
+                 Checks that the closing brace in a method definition is
+                 either on the same line as the last method parameter, or
+                 a new line.
   Enabled: true
 
 Style/MultilineOperationIndentation:
@@ -501,6 +545,17 @@ Style/NumericLiterals:
                  Add underscores to large numeric literals to improve their
                  readability.
   StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#underscores-in-numerics'
+  Enabled: true
+
+Style/NumericLiteralPrefix:
+  Description: 'Use smallcase prefixes for numeric literals.'
+  StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#numeric-literal-prefixes'
+  Enabled: true
+
+Style/NumericPredicate:
+  Description: >-
+                 Checks for the use of predicate- or comparison methods for
+                 numeric comparisons.
   Enabled: true
 
 Style/OneLineConditional:
@@ -716,6 +771,14 @@ Style/SpaceAroundOperators:
   StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#spaces-operators'
   Enabled: true
 
+Style/SpaceInsideArrayPercentLiteral:
+  Description: 'No unnecessary additional spaces between elements in %i/%w literals.'
+  Enabled: true
+
+Style/SpaceInsidePercentLiteralDelimiters:
+  Description: 'No unnecessary spaces inside delimiters of %i/%w/%x literals.'
+  Enabled: true
+
 Style/SpaceInsideBrackets:
   Description: 'No spaces after [ or before ].'
   StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#no-spaces-braces'
@@ -780,6 +843,10 @@ Style/Tab:
   StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#spaces-indentation'
   Enabled: true
 
+Style/TernaryParentheses:
+  Description: 'Checks for use of parentheses around ternary conditions.'
+  Enabled: true
+
 Style/TrailingBlankLines:
   Description: 'Checks trailing blank lines and final newline.'
   StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#newline-eof'
@@ -787,7 +854,7 @@ Style/TrailingBlankLines:
 
 Style/TrailingCommaInArguments:
   Description: 'Checks for trailing comma in argument lists.'
-  StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#no-trailing-array-commas'
+  StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#no-trailing-params-comma'
   Enabled: true
 
 Style/TrailingCommaInLiteral:
@@ -1035,6 +1102,10 @@ Lint/IneffectiveAccessModifier:
                  the visibility of a class method, which does not work.
   Enabled: true
 
+Lint/InheritException:
+  Description: 'Avoid inheriting from the `Exception` class.'
+  Enabled: true
+
 Lint/InvalidCharacterLiteral:
   Description: >-
                  Checks for invalid character literals with a non-escaped
@@ -1078,6 +1149,16 @@ Lint/ParenthesesAsGroupedExpression:
   StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#parens-no-spaces'
   Enabled: true
 
+Lint/PercentStringArray:
+  Description: >-
+                 Checks for unwanted commas and quotes in %w/%W literals.
+  Enabled: true
+
+Lint/PercentSymbolArray:
+  Description: >-
+                 Checks for unwanted commas and colons in %i/%I literals.
+  Enabled: true
+
 Lint/RandOne:
   Description: >-
                  Checks for `rand(1)` calls. Such calls always return `0`
@@ -1093,6 +1174,12 @@ Lint/RequireParentheses:
 Lint/RescueException:
   Description: 'Avoid rescuing the Exception class.'
   StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#no-blind-rescues'
+  Enabled: true
+
+Lint/ShadowedException:
+  Description: >-
+                  Avoid rescuing a higher level exception
+                  before a lower level exception.
   Enabled: true
 
 Lint/ShadowingOuterLocalVariable:
@@ -1133,6 +1220,11 @@ Lint/UnreachableCode:
 
 Lint/UselessAccessModifier:
   Description: 'Checks for useless access modifiers.'
+  Enabled: true
+  ContextCreatingMethods: []
+
+Lint/UselessArraySplat:
+  Description: 'Checks for useless array splats.'
   Enabled: true
 
 Lint/UselessAssignment:
@@ -1234,6 +1326,10 @@ Performance/LstripRstrip:
   Description: 'Use `strip` instead of `lstrip.rstrip`.'
   Enabled: true
 
+Performance/PushSplat:
+  Description: 'Use `concat` instead of `push(*)`.'
+  Enabled: true
+
 Performance/RangeInclude:
   Description: 'Use `Range#cover?` instead of `Range#include?`.'
   Reference: 'https://github.com/JuanitoFatas/fast-ruby#cover-vs-include-code'
@@ -1311,20 +1407,34 @@ Rails/Delegate:
   Description: 'Prefer delegate method for delegations.'
   Enabled: true
 
+Rails/Exit:
+  Description: >-
+                  Favor `fail`, `break`, `return`, etc. over `exit` in
+                  application or library code outside of Rake files to avoid
+                  exits during unit testing or running in production.
+  Enabled: true
+
 Rails/FindBy:
   Description: 'Prefer find_by over where.first.'
+  StyleGuide: 'https://github.com/bbatsov/rails-style-guide#find_by'
   Enabled: true
 
 Rails/FindEach:
   Description: 'Prefer all.find_each over all.find.'
+  StyleGuide: 'https://github.com/bbatsov/rails-style-guide#find-each'
   Enabled: true
 
 Rails/HasAndBelongsToMany:
   Description: 'Prefer has_many :through to has_and_belongs_to_many.'
+  StyleGuide: 'https://github.com/bbatsov/rails-style-guide#has-many-through'
   Enabled: true
 
 Rails/Output:
   Description: 'Checks for calls to puts, print, etc.'
+  Enabled: true
+
+Rails/OutputSafety:
+  Description: 'The use of `html_safe` or `raw` may be a security risk.'
   Enabled: true
 
 Rails/PluralizationGrammar:
@@ -1335,6 +1445,11 @@ Rails/ReadWriteAttribute:
   Description: >-
                  Checks for read_attribute(:attr) and
                  write_attribute(:attr, val).
+  StyleGuide: 'https://github.com/bbatsov/rails-style-guide#read-attribute'
+  Enabled: true
+
+Rails/RequestReferer:
+  Description: 'Use consistent syntax for request.referer.'
   Enabled: true
 
 Rails/ScopeArgs:
@@ -1345,6 +1460,10 @@ Rails/TimeZone:
   Description: 'Checks the correct usage of time zone aware methods.'
   StyleGuide: 'https://github.com/bbatsov/rails-style-guide#time'
   Reference: 'http://danilenko.org/2012/7/6/rails_timezones'
+  Enabled: true
+
+Rails/UniqBeforePluck:
+  Description: 'Prefer the use of uniq or distinct before pluck.'
   Enabled: true
 
 Rails/Validation:

--- a/config/upstream.yml
+++ b/config/upstream.yml
@@ -25,6 +25,8 @@ AllCops:
     - '**/Berksfile'
     - '**/Cheffile'
     - '**/Vagabondfile'
+    - '**/Fastfile'
+    - '**/*Fastfile'
   Exclude:
     - 'vendor/**/*'
   # Default formatter will be used if no -f/--format option is given.
@@ -63,9 +65,20 @@ AllCops:
   # which is "/tmp" on Unix-like systems, but could be something else on other
   # systems.
   CacheRootDirectory: /tmp
-  # What version of the Ruby interpreter is the inspected code intended to
+  # The default cache root directory is /tmp, which on most systems is
+  # writable by any system user. This means that it is possible for a
+  # malicious user to anticipate the location of Rubocop's cache directory,
+  # and create a symlink in its place that could cause Rubocop to overwrite
+  # unintended files, or read malicious input. If you are certain that your
+  # cache location is secure from this kind of attack, and wish to use a
+  # symlinked cache location, set this value to "true".
+  AllowSymlinksInCacheRootDirectory: false
+  # What MRI version of the Ruby interpreter is the inspected code intended to
   # run on? (If there is more than one, set this to the lowest version.)
-  TargetRubyVersion: 2.0
+  # If a value is specified for TargetRubyVersion then it is used.
+  # Else if .ruby-version exists and it contains an MRI version it is used.
+  # Otherwise we fallback to the oldest officially supported Ruby version (2.0).
+  TargetRubyVersion: ~
 
 # Indent private/protected/public as deep as method definitions
 Style/AccessModifierIndentation:
@@ -165,6 +178,9 @@ Style/AlignParameters:
   SupportedStyles:
     - with_first_parameter
     - with_fixed_indentation
+  # By default, the indentation width from Style/IndentationWidth is used
+  # But it can be overridden by setting this parameter
+  IndentationWidth: ~
 
 Style/AndOr:
   # Whether `and` and `or` are banned only in conditionals (conditionals)
@@ -425,10 +441,11 @@ Style/EmptyLinesAroundModuleBody:
 # AutoCorrectEncodingComment must match the regex
 # /#.*coding\s?[:=]\s?(?:UTF|utf)-8/
 Style/Encoding:
-  EnforcedStyle: always
+  EnforcedStyle: never
   SupportedStyles:
     - when_needed
     - always
+    - never
   AutoCorrectEncodingComment: '# encoding: utf-8'
 
 Style/ExtraSpacing:
@@ -518,8 +535,10 @@ Style/HashSyntax:
     - ruby19
     - ruby19_no_mixed_keys
     - hash_rockets
-# Force hashes that have a symbol value to use hash rockets
+  # Force hashes that have a symbol value to use hash rockets
   UseHashRocketsWithSymbolValues: false
+  # Do not suggest { a?: 1 } over { :a? => 1 } in ruby19 style
+  PreferHashRocketsForNonAlnumEndingSymbols: false
 
 Style/IfUnlessModifier:
   MaxLineLength: 80
@@ -590,6 +609,13 @@ Style/IndentHash:
   # But it can be overridden by setting this parameter
   IndentationWidth: ~
 
+Style/Lambda:
+  EnforcedStyle: line_count_dependent
+  SupportedStyles:
+    - line_count_dependent
+    - lambda
+    - literal
+
 Style/LambdaCall:
   EnforcedStyle: call
   SupportedStyles:
@@ -617,6 +643,12 @@ Style/NonNilCheck:
   # offenses for `!x.nil?` and does no changes that might change behavior.
   IncludeSemanticChanges: false
 
+Style/NumericPredicate:
+  EnforcedStyle: predicate
+  SupportedStyles:
+    - predicate
+    - comparison
+
 Style/MethodDefParentheses:
   EnforcedStyle: require_parentheses
   SupportedStyles:
@@ -629,6 +661,22 @@ Style/MethodName:
   SupportedStyles:
     - snake_case
     - camelCase
+
+Style/ModuleFunction:
+  EnforcedStyle: module_function
+  SupportedStyles:
+    - module_function
+    - extend_self
+
+Style/MultilineArrayBraceLayout:
+  EnforcedStyle: symmetrical
+  SupportedStyles:
+    # symmetrical: closing brace is positioned in same way as opening brace
+    # new_line: closing brace is always on a new line
+    # same_line: closing brace is always on the same line as last element
+    - symmetrical
+    - new_line
+    - same_line
 
 Style/MultilineAssignmentLayout:
   # The types of assignments which are subject to this rule.
@@ -648,14 +696,45 @@ Style/MultilineAssignmentLayout:
     # for the set of supported types.
     - new_line
 
+Style/MultilineHashBraceLayout:
+  EnforcedStyle: symmetrical
+  SupportedStyles:
+    # symmetrical: closing brace is positioned in same way as opening brace
+    # new_line: closing brace is always on a new line
+    # same_line: closing brace is always on same line as last element
+    - symmetrical
+    - new_line
+    - same_line
+
+Style/MultilineMethodCallBraceLayout:
+  EnforcedStyle: symmetrical
+  SupportedStyles:
+    # symmetrical: closing brace is positioned in same way as opening brace
+    # new_line: closing brace is always on a new line
+    # same_line: closing brace is always on the same line as last argument
+    - symmetrical
+    - new_line
+    - same_line
+
 Style/MultilineMethodCallIndentation:
   EnforcedStyle: aligned
   SupportedStyles:
     - aligned
     - indented
+    - indented_relative_to_receiver
   # By default, the indentation width from Style/IndentationWidth is used
   # But it can be overridden by setting this parameter
   IndentationWidth: ~
+
+Style/MultilineMethodDefinitionBraceLayout:
+  EnforcedStyle: symmetrical
+  SupportedStyles:
+    # symmetrical: closing brace is positioned in same way as opening brace
+    # new_line: closing brace is always on a new line
+    # same_line: closing brace is always on the same line as last parameter
+    - symmetrical
+    - new_line
+    - same_line
 
 Style/MultilineOperationIndentation:
   EnforcedStyle: aligned
@@ -668,6 +747,12 @@ Style/MultilineOperationIndentation:
 
 Style/NumericLiterals:
   MinDigits: 5
+
+Style/NumericLiteralPrefix:
+  EnforcedOctalStyle: zero_with_o
+  SupportedOctalStyles:
+    - zero_with_o
+    - zero_only
 
 Style/OptionHash:
   # A list of parameter names that will be flagged by this cop.
@@ -715,6 +800,10 @@ Style/PredicateName:
   # should still be accepted
   NameWhitelist:
     - is_a?
+  # Exclude Rspec specs because there is a strong convetion to write spec
+  # helpers in the form of `have_something` or `be_something`.
+  Exclude:
+    - 'spec/**/*'
 
 Style/RaiseArgs:
   EnforcedStyle: exploded
@@ -846,6 +935,9 @@ Style/SpaceInsideHashLiteralBraces:
   SupportedStyles:
     - space
     - no_space
+    # 'compact' normally requires a space inside hash braces, with the exception
+    # that successive left braces or right braces are collapsed together
+    - compact
 
 Style/SpaceInsideStringInterpolation:
   EnforcedStyle: no_space
@@ -864,6 +956,14 @@ Style/SymbolProc:
   # The names should be fairly unique, otherwise you'll end up ignoring lots of code.
   IgnoredMethods:
     - respond_to
+    - define_method
+
+Style/TernaryParentheses:
+  EnforcedStyle: require_no_parentheses
+  SupportedStyles:
+    - require_parentheses
+    - require_no_parentheses
+  AllowSafeAssignment: true
 
 Style/TrailingBlankLines:
   EnforcedStyle: final_newline
@@ -944,11 +1044,17 @@ Style/VariableName:
 Style/WhileUntilModifier:
   MaxLineLength: 80
 
+# WordArray enforces how array literals of word-like strings should be expressed.
 Style/WordArray:
   EnforcedStyle: percent
   SupportedStyles:
+    # percent style: %w(word1 word2)
     - percent
+    # bracket style: ['word1', 'word2']
     - brackets
+  # The MinSize option causes the WordArray rule to be ignored for arrays
+  # smaller than a certain size.  The rule is only applied to arrays
+  # whose element count is greater than or equal to MinSize.
   MinSize: 0
   # The regular expression WordRegex decides what is considered a word.
   WordRegex: !ruby/regexp '/\A[\p{Word}\n\t]+\z/'
@@ -1006,7 +1112,7 @@ Lint/AssignmentInCondition:
 Lint/BlockAlignment:
   # The value `start_of_block` means that the `end` should be aligned with line
   # where the `do` keyword appears.
-  # The value `start_of_line` means it should be aligned with the whole 
+  # The value `start_of_line` means it should be aligned with the whole
   # expression's starting line.
   # The value `either` means both are allowed.
   AlignWith: either
@@ -1042,9 +1148,17 @@ Lint/DefEndAlignment:
     - def
   AutoCorrect: false
 
+Lint/InheritException:
+  # The default base class in favour of `Exception`.
+  EnforcedStyle: runtime_error
+  SupportedStyles:
+    - runtime_error
+    - standard_error
+
 # Checks for unused block arguments
 Lint/UnusedBlockArgument:
   IgnoreEmptyBlocks: true
+  AllowUnusedKeywordArguments: false
 
 # Checks for unused method arguments.
 Lint/UnusedMethodArgument:
@@ -1078,6 +1192,14 @@ Rails/Date:
     - strict
     - flexible
 
+Rails/Exit:
+  Include:
+    - app/**/*.rb
+    - config/**/*.rb
+    - lib/**/*.rb
+  Exclude:
+    - lib/**/*.rake
+
 Rails/FindBy:
   Include:
     - app/models/**/*.rb
@@ -1101,6 +1223,12 @@ Rails/ReadWriteAttribute:
   Include:
     - app/models/**/*.rb
 
+Rails/RequestReferer:
+  EnforcedStyle: referer
+  SupportedStyles:
+    - referer
+    - referrer
+
 Rails/ScopeArgs:
   Include:
     - app/models/**/*.rb
@@ -1112,6 +1240,13 @@ Rails/TimeZone:
   SupportedStyles:
     - strict
     - flexible
+
+Rails/UniqBeforePluck:
+  EnforcedMode: conservative
+  SupportedModes:
+    - conservative
+    - aggressive
+  AutoCorrect: false
 
 Rails/Validation:
   Include:

--- a/lib/chefstyle/version.rb
+++ b/lib/chefstyle/version.rb
@@ -1,4 +1,4 @@
 module Chefstyle
-  VERSION = "0.3.1".freeze
+  VERSION = "0.4.0".freeze
   RUBOCOP_VERSION = "0.42.0".freeze
 end

--- a/lib/chefstyle/version.rb
+++ b/lib/chefstyle/version.rb
@@ -1,4 +1,4 @@
 module Chefstyle
   VERSION = "0.3.1".freeze
-  RUBOCOP_VERSION = "0.39.0".freeze
+  RUBOCOP_VERSION = "0.42.0".freeze
 end


### PR DESCRIPTION
also bumps the version for 0.4.0 since next step will be releasing after cleaning up ohai, etc.

closes #29 