### PR TITLE
enable style/semicolon

### DIFF
--- a/config/chefstyle.yml
+++ b/config/chefstyle.yml
@@ -322,6 +322,9 @@ Style/RedundantFreeze:
   Enabled: true
 Style/RescueEnsureAlignment:
   Enabled: true
+Style/Semicolon:
+  AllowAsExpressionSeparator: true
+  Enabled: true
 # we only 'raise' and do not 'fail'
 Style/SignalException:
   EnforcedStyle: only_raise


### PR DESCRIPTION
allow for separating single-line expressions (typically one liners with
anonymous functions with more than one statement, which often are
perfectly readable/idiomatic).

chef/chef PR is at https://github.com/chef/chef/pull/5543

Signed-off-by: Lamont Granquist <lamont@scriptkiddie.org>