### PR TITLE
bump target ruby to 2.3

### DIFF
--- a/config/chefstyle.yml
+++ b/config/chefstyle.yml
@@ -379,8 +379,9 @@ Style/RedundantSelf:
   Enabled: true
 Style/RescueEnsureAlignment:
   Enabled: true
+# temporarily disabled, but we should do this
 Style/SafeNavigation:
-  Enabled: true
+  Enabled: false
 Style/SelfAssignment:
   Enabled: true
 Style/Semicolon:
@@ -470,6 +471,10 @@ Style/WordArray:
 #
 # Disabled Style
 #
+
+# FIXME: we need to enable this
+Style/FrozenStringLiteralComment:
+  Enabled: false
 
 # As of this commit we have 686 modules and classes without docs.
 # This is a cop that we /should/ have enabled, but tactically we can't really enable.

--- a/config/chefstyle.yml
+++ b/config/chefstyle.yml
@@ -1,3 +1,6 @@
+AllCops:
+  TargetRubyVersion: 2.3
+
 #
 # Bundler
 #


### PR DESCRIPTION
we're dropping ruby 2.1/2.2 support everywhere (except for like
mixlib-install where i just specifically override this in that
project's .rubocop.yml file)

Signed-off-by: Lamont Granquist <lamont@scriptkiddie.org>