### PR TITLE
enable Security/Eval and all remaining Lint

### DIFF
--- a/config/chefstyle.yml
+++ b/config/chefstyle.yml
@@ -14,6 +14,12 @@ Bundler/DuplicatedGem:
 
 Lint/AmbiguousOperator:
   Enabled: true
+Lint/AmbiguousBlockAssociation:
+  Enabled: true
+Lint/AmbiguousRegexpLiteral:
+  Enabled: true
+Lint/AssignmentInCondition:
+  Enabled: true
 Lint/BlockAlignment:
   Enabled: true
 Lint/CircularArgumentReference:
@@ -23,6 +29,8 @@ Lint/ConditionPosition:
 Lint/Debugger:
   Enabled: true
 Lint/DefEndAlignment:
+  Enabled: true
+Lint/DeprecatedClassMethods:
   Enabled: true
 Lint/DuplicateCaseCondition:
   Enabled: true
@@ -40,6 +48,8 @@ Lint/EmptyExpression:
   Enabled: true
 Lint/EmptyInterpolation:
   Enabled: true
+Lint/EmptyWhen:
+  Enabled: true
 Lint/EndAlignment:
   Enabled: true
 Lint/EndInMethod:
@@ -53,6 +63,8 @@ Lint/FormatParameterMismatch:
 Lint/ImplicitStringConcatenation:
   Enabled: true
 Lint/InheritException:
+  Enabled: true
+Lint/IneffectiveAccessModifier:
   Enabled: true
 Lint/InvalidCharacterLiteral:
   Enabled: true
@@ -70,6 +82,10 @@ Lint/NextWithoutAccumulator:
   Enabled: true
 Lint/NonLocalExitFromIterator:
   Enabled: true
+Lint/ParenthesesAsGroupedExpression:
+  Enabled: true
+Lint/PercentStringArray:
+  Enabled: true
 Lint/PercentSymbolArray:
   Enabled: true
 Lint/RandOne:
@@ -77,6 +93,10 @@ Lint/RandOne:
 Lint/RequireParentheses:
   Enabled: true
 Lint/SafeNavigationChain:
+  Enabled: true
+Lint/ShadowedException:
+  Enabled: true
+Lint/ShadowingOuterLocalVariable:
   Enabled: true
 Lint/StringConversionInInterpolation:
   Enabled: true
@@ -86,9 +106,13 @@ Lint/UnifiedInteger:
   Enabled: true
 Lint/UnneededDisable:
   Enabled: true
+Lint/UnneededSplatExpansion:
+  Enabled: true
 Lint/UnreachableCode:
   Enabled: true
 Lint/UselessAccessModifier:
+  Enabled: true
+Lint/UselessAssignment:
   Enabled: true
 Lint/UselessComparison:
   Enabled: true
@@ -114,10 +138,6 @@ Lint/HandleExceptions:
   Enabled: false
 # We also decorate Exceptions a lot
 Lint/RescueException:
-  Enabled: false
-
-# we have lots of not-insecure uses of eval
-Security/Eval:
   Enabled: false
 
 # disabling this will make it easier to stage chefstyle rollouts
@@ -204,6 +224,13 @@ Rails/ScopeArgs:
 Rails/TimeZone:
   Enabled: true
 Rails/Validation:
+  Enabled: true
+
+#
+# Security
+#
+
+Security/Eval:
   Enabled: true
 
 #


### PR DESCRIPTION
the one that seems most problematic here is actually `Lint/AssignmentInCondition` where we have 71 offenses that look like they're correctly using assignment in conditionals.  e.g.:

```
until exitstatus = Process.waitpid2(pid, Process::WNOHANG)
```

and

```
if match = line.match(/^.*?:.*?: \s+(.*)/)
```
