### PR TITLE
bump rubocop to 0.54.0

### DIFF
--- a/config/chefstyle.yml
+++ b/config/chefstyle.yml
@@ -20,15 +20,15 @@ Lint/AmbiguousRegexpLiteral:
   Enabled: true
 Lint/AssignmentInCondition:
   Enabled: true
-Lint/BlockAlignment:
+Layout/BlockAlignment:
   Enabled: true
 Lint/CircularArgumentReference:
   Enabled: true
-Lint/ConditionPosition:
+Layout/ConditionPosition:
   Enabled: true
 Lint/Debugger:
   Enabled: true
-Lint/DefEndAlignment:
+Layout/DefEndAlignment:
   Enabled: true
 Lint/DeprecatedClassMethods:
   Enabled: true
@@ -50,7 +50,7 @@ Lint/EmptyInterpolation:
   Enabled: true
 Lint/EmptyWhen:
   Enabled: true
-Lint/EndAlignment:
+Layout/EndAlignment:
   Enabled: true
 Lint/EndInMethod:
   Enabled: true

--- a/config/disable_all.yml
+++ b/config/disable_all.yml
@@ -19,6 +19,8 @@ Layout/AlignHash:
   Enabled: false
 Layout/AlignParameters:
   Enabled: false
+Layout/BlockAlignment:
+  Enabled: false
 Layout/BlockEndNewline:
   Enabled: false
 Layout/CaseIndentation:
@@ -29,9 +31,15 @@ Layout/ClosingParenthesisIndentation:
   Enabled: false
 Layout/CommentIndentation:
   Enabled: false
+Layout/ConditionPosition:
+  Enabled: false
+Layout/DefEndAlignment:
+  Enabled: false
 Layout/DotPosition:
   Enabled: false
 Layout/ElseAlignment:
+  Enabled: false
+Layout/EmptyComment:
   Enabled: false
 Layout/EmptyLineAfterMagicComment:
   Enabled: false
@@ -54,6 +62,8 @@ Layout/EmptyLinesAroundMethodBody:
 Layout/EmptyLinesAroundModuleBody:
   Enabled: false
 Layout/EmptyLines:
+  Enabled: false
+Layout/EndAlignment:
   Enabled: false
 Layout/EndOfLine:
   Enabled: false
@@ -165,17 +175,13 @@ Lint/AmbiguousRegexpLiteral:
   Enabled: false
 Lint/AssignmentInCondition:
   Enabled: false
-Lint/BlockAlignment:
+Lint/BigDecimalNew:
   Enabled: false
 Lint/BooleanSymbol:
   Enabled: false
 Lint/CircularArgumentReference:
   Enabled: false
-Lint/ConditionPosition:
-  Enabled: false
 Lint/Debugger:
-  Enabled: false
-Lint/DefEndAlignment:
   Enabled: false
 Lint/DeprecatedClassMethods:
   Enabled: false
@@ -196,8 +202,6 @@ Lint/EmptyExpression:
 Lint/EmptyInterpolation:
   Enabled: false
 Lint/EmptyWhen:
-  Enabled: false
-Lint/EndAlignment:
   Enabled: false
 Lint/EndInMethod:
   Enabled: false
@@ -234,6 +238,10 @@ Lint/NestedPercentLiteral:
 Lint/NextWithoutAccumulator:
   Enabled: false
 Lint/NonLocalExitFromIterator:
+  Enabled: false
+Lint/NumberConversion:
+  Enabled: false
+Lint/OrderedMagicComments:
   Enabled: false
 Lint/ParenthesesAsGroupedExpression:
   Enabled: false
@@ -275,7 +283,9 @@ Lint/UnderscorePrefixedVariableName:
   Enabled: false
 Lint/UnifiedInteger:
   Enabled: false
-Lint/UnneededDisable:
+Lint/UnneededCopDisableDirective:
+  Enabled: false
+Lint/UnneededCopEnableDirective:
   Enabled: false
 Lint/UnneededRequireStatement:
   Enabled: false
@@ -337,11 +347,17 @@ Naming/HeredocDelimiterCase:
   Enabled: false
 Naming/HeredocDelimiterNaming:
   Enabled: false
+Naming/MemoizedInstanceVariableName:
+  Enabled: false
 Naming/MethodName:
   Enabled: false
 Naming/BinaryOperatorParameterName:
   Enabled: false
 Naming/PredicateName:
+  Enabled: false
+Naming/UncommunicativeBlockParamName:
+  Enabled: false
+Naming/UncommunicativeMethodParamName:
   Enabled: false
 Naming/VariableName:
   Enabled: false
@@ -364,8 +380,6 @@ Performance/EndWith:
 Performance/FixedSize:
   Enabled: false
 Performance/FlatMap:
-  Enabled: false
-Performance/HashEachMethods:
   Enabled: false
 Performance/LstripRstrip:
   Enabled: false
@@ -473,6 +487,8 @@ Style/EmptyElse:
   Enabled: false
 Style/EmptyLambdaParameter:
   Enabled: false
+Style/EmptyLineAfterGuardClause:
+  Enabled: false
 Style/EmptyLiteral:
   Enabled: false
 Style/EmptyMethod:
@@ -484,6 +500,8 @@ Style/EndBlock:
 Style/EvalWithLocation:
   Enabled: false
 Style/EvenOdd:
+  Enabled: false
+Style/ExpandPathArguments:
   Enabled: false
 Style/FlipFlop:
   Enabled: false
@@ -669,11 +687,17 @@ Style/SymbolProc:
   Enabled: false
 Style/TernaryParentheses:
   Enabled: false
+Style/TrailingBodyOnClass:
+  Enabled: false
 Style/TrailingBodyOnMethodDefinition:
+  Enabled: false
+Style/TrailingBodyOnModule:
   Enabled: false
 Style/TrailingCommaInArguments:
   Enabled: false
-Style/TrailingCommaInLiteral:
+Style/TrailingCommaInArrayLiteral:
+  Enabled: false
+Style/TrailingCommaInHashLiteral:
   Enabled: false
 Style/TrailingMethodEndStatement:
   Enabled: false
@@ -688,6 +712,8 @@ Style/UnneededCapitalW:
 Style/UnneededInterpolation:
   Enabled: false
 Style/UnneededPercentQ:
+  Enabled: false
+Style/UnpackFirst:
   Enabled: false
 Style/VariableInterpolation:
   Enabled: false
@@ -704,6 +730,8 @@ Style/YodaCondition:
 Style/ZeroLengthPredicate:
   Enabled: false
 Rails/ActionFilter:
+  Enabled: false
+Rails/ActiveRecordAliases:
   Enabled: false
 Rails/ActiveSupportAliases:
   Enabled: false
@@ -740,6 +768,8 @@ Rails/HasAndBelongsToMany:
 Rails/HasManyOrHasOneDependent:
   Enabled: false
 Rails/HttpPositionalArguments:
+  Enabled: false
+Rails/HttpStatus:
   Enabled: false
 Rails/InverseOf:
   Enabled: false
@@ -788,6 +818,8 @@ Security/Eval:
 Security/JSONLoad:
   Enabled: false
 Security/MarshalLoad:
+  Enabled: false
+Security/Open:
   Enabled: false
 Security/YAMLLoad:
   Enabled: false

--- a/config/disabled.yml
+++ b/config/disabled.yml
@@ -34,6 +34,10 @@ Layout/MultilineAssignmentLayout:
   StyleGuide: '#indent-conditional-assignment'
   Enabled: false
 
+Lint/NumberConversion:
+  Description: 'Checks unsafe usage of number conversion methods.'
+  Enabled: false
+
 # By default, the rails cops are not run. Override in project or home
 # directory .rubocop.yml files, or by giving the -R/--rails option.
 Rails:
@@ -64,6 +68,10 @@ Style/DocumentationMethod:
     - 'spec/**/*'
     - 'test/**/*'
 
+Style/EmptyLineAfterGuardClause:
+  Description: 'Add empty line after guard clause.'
+  Enabled: false
+
 Style/ImplicitRuntimeError:
   Description: >-
                  Use `raise` or `fail` with an explicit exception class and
@@ -92,14 +100,6 @@ Style/MissingElse:
                 This will conflict with Style/EmptyElse if
                 Style/EmptyElse is configured to style "both"
   Enabled: false
-  EnforcedStyle: both
-  SupportedStyles:
-    # if - warn when an if expression is missing an else branch
-    # case - warn when a case expression is missing an else branch
-    # both - warn when an if or case expression is missing an else branch
-    - if
-    - case
-    - both
 
 Style/OptionHash:
   Description: "Don't use option hashes when you can use keyword arguments."

--- a/config/enabled.yml
+++ b/config/enabled.yml
@@ -6,6 +6,7 @@ Bundler/DuplicatedGem:
   Description: 'Checks for duplicate gem entries in Gemfile.'
   Enabled: true
   Include:
+    - '**/*.gemfile'
     - '**/Gemfile'
     - '**/gems.rb'
 
@@ -16,6 +17,7 @@ Bundler/InsecureProtocolSource:
                  'https://rubygems.org' if possible, or 'http://rubygems.org' if not.
   Enabled: true
   Include:
+    - '**/*.gemfile'
     - '**/Gemfile'
     - '**/gems.rb'
 
@@ -24,6 +26,7 @@ Bundler/OrderedGems:
                  Gems within groups in the Gemfile should be alphabetically sorted.
   Enabled: true
   Include:
+    - '**/*.gemfile'
     - '**/Gemfile'
     - '**/gems.rb'
 
@@ -75,6 +78,10 @@ Layout/AlignParameters:
   StyleGuide: '#no-double-indent'
   Enabled: true
 
+Layout/BlockAlignment:
+  Description: 'Align block ends correctly.'
+  Enabled: true
+
 Layout/BlockEndNewline:
   Description: 'Put end statement of multiline block on its own line.'
   Enabled: true
@@ -92,6 +99,17 @@ Layout/CommentIndentation:
   Description: 'Indentation of comments.'
   Enabled: true
 
+Layout/ConditionPosition:
+  Description: >-
+                 Checks for condition placed in a confusing position relative to
+                 the keyword.
+  StyleGuide: '#same-line-condition'
+  Enabled: true
+
+Layout/DefEndAlignment:
+  Description: 'Align ends corresponding to defs correctly.'
+  Enabled: true
+
 Layout/DotPosition:
   Description: 'Checks the position of the dot in multi-line method calls.'
   StyleGuide: '#consistent-multi-line-chains'
@@ -99,6 +117,10 @@ Layout/DotPosition:
 
 Layout/ElseAlignment:
   Description: 'Align elses and elsifs correctly.'
+  Enabled: true
+
+Layout/EmptyComment:
+  Description: 'Checks empty comment.'
   Enabled: true
 
 Layout/EmptyLineAfterMagicComment:
@@ -153,6 +175,10 @@ Layout/EmptyLinesAroundMethodBody:
 Layout/EmptyLinesAroundModuleBody:
   Description: "Keeps track of empty lines around module bodies."
   StyleGuide: '#empty-lines-around-bodies'
+  Enabled: true
+
+Layout/EndAlignment:
+  Description: 'Align ends correctly.'
   Enabled: true
 
 Layout/EndOfLine:
@@ -421,8 +447,8 @@ Lint/AssignmentInCondition:
   StyleGuide: '#safe-assignment-in-condition'
   Enabled: true
 
-Lint/BlockAlignment:
-  Description: 'Align block ends correctly.'
+Lint/BigDecimalNew:
+  Description: '`BigDecimal.new()` is deprecated. Use `BigDecimal()` instead.'
   Enabled: true
 
 Lint/BooleanSymbol:
@@ -433,19 +459,8 @@ Lint/CircularArgumentReference:
   Description: "Default values in optional keyword arguments and optional ordinal arguments should not refer back to the name of the argument."
   Enabled: true
 
-Lint/ConditionPosition:
-  Description: >-
-                 Checks for condition placed in a confusing position relative to
-                 the keyword.
-  StyleGuide: '#same-line-condition'
-  Enabled: true
-
 Lint/Debugger:
   Description: 'Check for debugger calls.'
-  Enabled: true
-
-Lint/DefEndAlignment:
-  Description: 'Align ends corresponding to defs correctly.'
   Enabled: true
 
 Lint/DeprecatedClassMethods:
@@ -487,10 +502,6 @@ Lint/EmptyInterpolation:
 
 Lint/EmptyWhen:
   Description: 'Checks for `when` branches with empty bodies.'
-  Enabled: true
-
-Lint/EndAlignment:
-  Description: 'Align ends correctly.'
   Enabled: true
 
 Lint/EndInMethod:
@@ -577,6 +588,10 @@ Lint/NextWithoutAccumulator:
 
 Lint/NonLocalExitFromIterator:
   Description: 'Do not use return in iterator to cause non-local exit.'
+  Enabled: true
+
+Lint/OrderedMagicComments:
+  Description: 'Checks the proper ordering of magic comments and whether a magic comment is not placed before a shebang.'
   Enabled: true
 
 Lint/ParenthesesAsGroupedExpression:
@@ -676,11 +691,16 @@ Lint/UnifiedInteger:
   Description: 'Use Integer instead of Fixnum or Bignum'
   Enabled: true
 
-Lint/UnneededDisable:
+Lint/UnneededCopDisableDirective:
   Description: >-
                  Checks for rubocop:disable comments that can be removed.
                  Note: this cop is not disabled when disabling all cops.
                  It must be explicitly disabled.
+  Enabled: true
+
+Lint/UnneededCopEnableDirective:
+  Description: Checks for rubocop:enable comments that can be removed.
+
   Enabled: true
 
 Lint/UnneededRequireStatement:
@@ -841,6 +861,11 @@ Naming/HeredocDelimiterNaming:
   StyleGuide: '#heredoc-delimiters'
   Enabled: true
 
+Naming/MemoizedInstanceVariableName:
+  Description: >-
+    Memoized method name should match memo instance variable name.
+  Enabled: true
+
 Naming/MethodName:
   Description: 'Use the configured style when naming methods.'
   StyleGuide: '#snake-case-symbols-methods-vars'
@@ -849,6 +874,18 @@ Naming/MethodName:
 Naming/PredicateName:
   Description: 'Check the names of predicate methods.'
   StyleGuide: '#bool-methods-qmark'
+  Enabled: true
+
+Naming/UncommunicativeBlockParamName:
+  Description: >-
+                Checks for block parameter names that contain capital letters,
+                end in numbers, or do not meet a minimal length.
+  Enabled: true
+
+Naming/UncommunicativeMethodParamName:
+  Description: >-
+                Checks for method parameter names that contain capital letters,
+                end in numbers, or do not meet a minimal length.
   Enabled: true
 
 Naming/VariableName:
@@ -939,14 +976,6 @@ Performance/FlatMap:
   # This can be dangerous since `flat_map` will only flatten 1 level, and
   # `flatten` without any parameters can flatten multiple levels.
 
-Performance/HashEachMethods:
-  Description: >-
-                 Use `Hash#each_key` and `Hash#each_value` instead of
-                 `Hash#keys.each` and `Hash#values.each`.
-  StyleGuide: '#hash-each'
-  Enabled: true
-  AutoCorrect: false
-
 Performance/LstripRstrip:
   Description: 'Use `strip` instead of `lstrip.rstrip`.'
   Enabled: true
@@ -1035,6 +1064,13 @@ Performance/UriDefaultParser:
 
 Rails/ActionFilter:
   Description: 'Enforces consistent use of action filter methods.'
+  Enabled: true
+
+Rails/ActiveRecordAliases:
+  Description: >-
+                  Avoid Active Record aliases:
+                  Use `update` instead of `update_attributes`.
+                  Use `update!` instead of `update_attributes!`.
   Enabled: true
 
 Rails/ActiveSupportAliases:
@@ -1132,6 +1168,10 @@ Rails/HttpPositionalArguments:
   Include:
     - 'spec/**/*'
     - 'test/**/*'
+
+Rails/HttpStatus:
+  Description: 'Enforces use of symbolic or numeric value to define HTTP status.'
+  Enabled: true
 
 Rails/InverseOf:
   Description: 'Checks for associations where the inverse cannot be determined automatically.'
@@ -1251,6 +1291,10 @@ Security/MarshalLoad:
                  Avoid using of `Marshal.load` or `Marshal.restore` due to potential
                  security issues. See reference for more information.
   Reference: 'http://ruby-doc.org/core-2.3.3/Marshal.html#module-Marshal-label-Security+considerations'
+  Enabled: true
+
+Security/Open:
+  Description: 'The use of Kernel#open represents a serious security risk.'
   Enabled: true
 
 Security/YAMLLoad:
@@ -1463,6 +1507,10 @@ Style/EvalWithLocation:
 Style/EvenOdd:
   Description: 'Favor the use of Integer#even? && Integer#odd?'
   StyleGuide: '#predicate-methods'
+  Enabled: true
+
+Style/ExpandPathArguments:
+  Description: "Use `expand_path(__dir__)` instead of `expand_path('..', __FILE__)`."
   Enabled: true
 
 Style/FlipFlop:
@@ -1900,8 +1948,16 @@ Style/TernaryParentheses:
   Description: 'Checks for use of parentheses around ternary conditions.'
   Enabled: true
 
+Style/TrailingBodyOnClass:
+  Description: 'Class body goes below class statement.'
+  Enabled: true
+
 Style/TrailingBodyOnMethodDefinition:
   Description: 'Method body goes below definition.'
+  Enabled: true
+
+Style/TrailingBodyOnModule:
+  Description: 'Module body goes below module statement.'
   Enabled: true
 
 Style/TrailingCommaInArguments:
@@ -1909,9 +1965,13 @@ Style/TrailingCommaInArguments:
   StyleGuide: '#no-trailing-params-comma'
   Enabled: true
 
-Style/TrailingCommaInLiteral:
-  Description: 'Checks for trailing comma in array and hash literals.'
+Style/TrailingCommaInArrayLiteral:
+  Description: 'Checks for trailing comma in array literals.'
   StyleGuide: '#no-trailing-array-commas'
+  Enabled: true
+
+Style/TrailingCommaInHashLiteral:
+  Description: 'Checks for trailing comma in hash literals.'
   Enabled: true
 
 Style/TrailingMethodEndStatement:
@@ -1948,6 +2008,12 @@ Style/UnneededInterpolation:
 Style/UnneededPercentQ:
   Description: 'Checks for %q/%Q when single quotes or double quotes would do.'
   StyleGuide: '#percent-q'
+  Enabled: true
+
+Style/UnpackFirst:
+  Description: >-
+                 Checks for accessing the first element of `String#unpack`
+                 instead of using `unpack1`
   Enabled: true
 
 Style/VariableInterpolation:

--- a/config/upstream.yml
+++ b/config/upstream.yml
@@ -9,8 +9,11 @@ inherit_from:
 AllCops:
   # Include common Ruby source files.
   Include:
+    - '**/*.arb'
+    - '**/*.axlsx'
     - '**/*.builder'
     - '**/*.fcgi'
+    - '**/*.gemfile'
     - '**/*.gemspec'
     - '**/*.god'
     - '**/*.jb'
@@ -57,6 +60,7 @@ AllCops:
   Exclude:
     - 'node_modules/**/*'
     - 'vendor/**/*'
+    - '.git/**/*'
   # Default formatter will be used if no `-f/--format` option is given.
   DefaultFormatter: progress
   # Cop names are displayed in offense messages by default. Change behavior
@@ -111,11 +115,24 @@ AllCops:
   AllowSymlinksInCacheRootDirectory: false
   # What MRI version of the Ruby interpreter is the inspected code intended to
   # run on? (If there is more than one, set this to the lowest version.)
-  # If a value is specified for TargetRubyVersion then it is used.
-  # Else if .ruby-version exists and it contains an MRI version it is used.
-  # Otherwise we fallback to the oldest officially supported Ruby version (2.1).
+  # If a value is specified for TargetRubyVersion then it is used. Acceptable
+  # values are specificed as a float (i.e. 2.5); the teeny version of Ruby
+  # should not be included. If the project specifies a Ruby version in the
+  # .ruby-version file, Gemfile or gems.rb file, RuboCop will try to determine
+  # the desired version of Ruby by inspecting the .ruby-version file first,
+  # followed by the Gemfile.lock or gems.locked file. (Although the Ruby version
+  # is specified in the Gemfile or gems.rb file, RuboCop reads the final value
+  # from the lock file.) If the Ruby version is still unresolved, RuboCop will
+  # use the oldest officially supported Ruby version (currently Ruby 2.1).
   TargetRubyVersion: ~
-  TargetRailsVersion: 5.0
+  # What version of Rails is the inspected code using?  If a value is specified
+  # for TargetRailsVersion then it is used.  Acceptable values are specificed
+  # as a float (i.e. 5.1); the patch version of Rails should not be included.
+  # If TargetRailsVersion is not set, RuboCop will parse the Gemfile.lock or
+  # gems.locked file to find the version of Rails that has been bound to the
+  # application.  If neither of those files exist, RuboCop will use Rails 5.0
+  # as the default.
+  TargetRailsVersion: ~
 
 #################### Layout ###########################
 
@@ -223,6 +240,19 @@ Layout/AlignParameters:
   # But it can be overridden by setting this parameter
   IndentationWidth: ~
 
+# checks whether the end keywords are aligned properly for `do` `end` blocks.
+Layout/BlockAlignment:
+  # The value `start_of_block` means that the `end` should be aligned with line
+  # where the `do` keyword appears.
+  # The value `start_of_line` means it should be aligned with the whole
+  # expression's starting line.
+  # The value `either` means both are allowed.
+  EnforcedStyleAlignWith: either
+  SupportedStylesAlignWith:
+    - either
+    - start_of_block
+    - start_of_line
+
 # Indentation of `when`.
 Layout/CaseIndentation:
   EnforcedStyle: case
@@ -235,12 +265,28 @@ Layout/CaseIndentation:
   # This only matters if `IndentOneStep` is `true`
   IndentationWidth: ~
 
+Layout/DefEndAlignment:
+  # The value `def` means that `end` should be aligned with the def keyword.
+  # The value `start_of_line` means that `end` should be aligned with method
+  # calls like `private`, `public`, etc, if present in front of the `def`
+  # keyword on the same line.
+  EnforcedStyleAlignWith: start_of_line
+  SupportedStylesAlignWith:
+    - start_of_line
+    - def
+  AutoCorrect: false
+  Severity: warning
+
 # Multi-line method chaining should be done with leading dots.
 Layout/DotPosition:
   EnforcedStyle: leading
   SupportedStyles:
     - leading
     - trailing
+
+Layout/EmptyComment:
+  AllowBorderComment: true
+  AllowMarginComment: true
 
 # Use empty lines between defs.
 Layout/EmptyLineBetweenDefs:
@@ -263,6 +309,8 @@ Layout/EmptyLinesAroundClassBody:
     - empty_lines_except_namespace
     - empty_lines_special
     - no_empty_lines
+    - beginning_only
+    - ending_only
 
 Layout/EmptyLinesAroundModuleBody:
   EnforcedStyle: no_empty_lines
@@ -271,6 +319,23 @@ Layout/EmptyLinesAroundModuleBody:
     - empty_lines_except_namespace
     - empty_lines_special
     - no_empty_lines
+
+# Align ends correctly.
+Layout/EndAlignment:
+  # The value `keyword` means that `end` should be aligned with the matching
+  # keyword (`if`, `while`, etc.).
+  # The value `variable` means that in assignments, `end` should be aligned
+  # with the start of the variable on the left hand side of `=`. In all other
+  # situations, `end` should still be aligned with the keyword.
+  # The value `start_of_line` means that `end` should be aligned with the start
+  # of the line which the matching keyword appears on.
+  EnforcedStyleAlignWith: keyword
+  SupportedStylesAlignWith:
+    - keyword
+    - variable
+    - start_of_line
+  AutoCorrect: false
+  Severity: warning
 
 Layout/EndOfLine:
   # The `native` style means that CR+LF (Carriage Return + Line Feed) is
@@ -544,6 +609,10 @@ Layout/SpaceInsideReferenceBrackets:
   SupportedStyles:
     - space
     - no_space
+  EnforcedStyleForEmptyBrackets: no_space
+  SupportedStylesForEmptyBrackets:
+    - space
+    - no_space
 
 Layout/SpaceInsideStringInterpolation:
   EnforcedStyle: no_space
@@ -681,6 +750,27 @@ Naming/PredicateName:
   # helpers in the form of `have_something` or `be_something`.
   Exclude:
     - 'spec/**/*'
+
+Naming/UncommunicativeBlockParamName:
+  # Parameter names may be equal to or greater than this value
+  MinNameLength: 1
+  AllowNamesEndingInNumbers: true
+  # Whitelisted names that will not register an offense
+  AllowedNames: []
+  # Blacklisted names that will register an offense
+  ForbiddenNames: []
+
+Naming/UncommunicativeMethodParamName:
+  # Parameter names may be equal to or greater than this value
+  MinNameLength: 3
+  AllowNamesEndingInNumbers: true
+  # Whitelisted names that will not register an offense
+  AllowedNames:
+    - io
+    - id
+    - to
+  # Blacklisted names that will register an offense
+  ForbiddenNames: []
 
 Naming/VariableName:
   EnforcedStyle: snake_case
@@ -931,8 +1021,8 @@ Style/EmptyMethod:
 Style/For:
   EnforcedStyle: each
   SupportedStyles:
-    - for
     - each
+    - for
 
 # Enforce the method used for string formatting.
 Style/FormatString:
@@ -1037,6 +1127,16 @@ Style/MethodDefParentheses:
     - require_parentheses
     - require_no_parentheses
     - require_no_parentheses_except_multiline
+
+Style/MissingElse:
+  EnforcedStyle: both
+  SupportedStyles:
+    # if - warn when an if expression is missing an else branch
+    # case - warn when a case expression is missing an else branch
+    # both - warn when an if or case expression is missing an else branch
+    - if
+    - case
+    - both
 
 # Checks the grouping of mixins (`include`, `extend`, `prepend`) in `class` and
 # `module` bodies.
@@ -1210,6 +1310,11 @@ Style/SafeNavigation:
   # Safe navigation may cause a statement to start returning `nil` in addition
   # to whatever it used to return.
   ConvertCodeThatCanStartToReturnNil: false
+  Whitelist:
+    - present?
+    - blank?
+    - presence
+    - try
 
 Style/Semicolon:
   # Allow `;` to separate several expressions on the same line.
@@ -1304,11 +1409,22 @@ Style/TrailingCommaInArguments:
     - consistent_comma
     - no_comma
 
-Style/TrailingCommaInLiteral:
-  # If `comma`, the cop requires a comma after the last item in an array or
-  # hash, but only when each item is on its own line.
+Style/TrailingCommaInArrayLiteral:
+  # If `comma`, the cop requires a comma after the last item in an array,
+  # but only when each item is on its own line.
   # If `consistent_comma`, the cop requires a comma after the last item of all
-  # non-empty array and hash literals.
+  # non-empty array literals.
+  EnforcedStyleForMultiline: no_comma
+  SupportedStylesForMultiline:
+    - comma
+    - consistent_comma
+    - no_comma
+
+Style/TrailingCommaInHashLiteral:
+  # If `comma`, the cop requires a comma after the last item in a hash,
+  # but only when each item is on its own line.
+  # If `consistent_comma`, the cop requires a comma after the last item of all
+  # non-empty hash literals.
   EnforcedStyleForMultiline: no_comma
   SupportedStylesForMultiline:
     - comma
@@ -1442,46 +1558,6 @@ Metrics/PerceivedComplexity:
 Lint/AssignmentInCondition:
   AllowSafeAssignment: true
 
-# checks whether the end keywords are aligned properly for `do` `end` blocks.
-Lint/BlockAlignment:
-  # The value `start_of_block` means that the `end` should be aligned with line
-  # where the `do` keyword appears.
-  # The value `start_of_line` means it should be aligned with the whole
-  # expression's starting line.
-  # The value `either` means both are allowed.
-  EnforcedStyleAlignWith: either
-  SupportedStylesAlignWith:
-    - either
-    - start_of_block
-    - start_of_line
-
-Lint/DefEndAlignment:
-  # The value `def` means that `end` should be aligned with the def keyword.
-  # The value `start_of_line` means that `end` should be aligned with method
-  # calls like `private`, `public`, etc, if present in front of the `def`
-  # keyword on the same line.
-  EnforcedStyleAlignWith: start_of_line
-  SupportedStylesAlignWith:
-    - start_of_line
-    - def
-  AutoCorrect: false
-
-# Align ends correctly.
-Lint/EndAlignment:
-  # The value `keyword` means that `end` should be aligned with the matching
-  # keyword (`if`, `while`, etc.).
-  # The value `variable` means that in assignments, `end` should be aligned
-  # with the start of the variable on the left hand side of `=`. In all other
-  # situations, `end` should still be aligned with the keyword.
-  # The value `start_of_line` means that `end` should be aligned with the start
-  # of the line which the matching keyword appears on.
-  EnforcedStyleAlignWith: keyword
-  SupportedStylesAlignWith:
-    - keyword
-    - variable
-    - start_of_line
-  AutoCorrect: false
-
 Lint/InheritException:
   # The default base class in favour of `Exception`.
   EnforcedStyle: runtime_error
@@ -1519,6 +1595,9 @@ Lint/UnusedBlockArgument:
 Lint/UnusedMethodArgument:
   AllowUnusedKeywordArguments: false
   IgnoreEmptyMethods: true
+
+Lint/Void:
+  CheckForMethodsWithNoSideEffects: false
 
 #################### Performance ###########################
 
@@ -1593,6 +1672,12 @@ Rails/HasAndBelongsToMany:
 Rails/HasManyOrHasOneDependent:
   Include:
     - app/models/**/*.rb
+
+Rails/HttpStatus:
+  EnforcedStyle: symbolic
+  SupportedStyles:
+    - numeric
+    - symbolic
 
 Rails/InverseOf:
   Include:

--- a/lib/chefstyle/version.rb
+++ b/lib/chefstyle/version.rb
@@ -1,4 +1,4 @@
 module Chefstyle
-  VERSION = "0.8.0".freeze
-  RUBOCOP_VERSION = "0.52.1".freeze
+  VERSION = "0.9.0".freeze
+  RUBOCOP_VERSION = "0.54.0".freeze
 end


### PR DESCRIPTION
we need to bump to at least 0.53.0 to remove the deprecation warning error message https://github.com/bbatsov/rubocop/issues/5662#issuecomment-372020867