### PR TITLE
make hash alignment less annoying

### DIFF
--- a/config/chefstyle.yml
+++ b/config/chefstyle.yml
@@ -269,6 +269,7 @@ Layout/AccessModifierIndentation:
   Enabled: true
 Layout/AlignHash:
   Enabled: true
+  EnforcedLastArgumentHashStyle: ignore_implicit
 Style/AndOr:
   Enabled: true
 Style/ArrayJoin:


### PR DESCRIPTION
allows this layout in implicit functions:

foo(this: this, that: that, another: another,
  thing: thing)

Signed-off-by: Lamont Granquist <lamont@scriptkiddie.org>