### PR TITLE
disable Style/UnneededInterpolation

### DIFF
--- a/config/chefstyle.yml
+++ b/config/chefstyle.yml
@@ -502,7 +502,7 @@ Layout/TrailingWhitespace:
 Style/UnneededCapitalW:
   Enabled: true
 Style/UnneededInterpolation:
-  Enabled: true
+  Enabled: false # buggy: https://github.com/rubocop-hq/rubocop/issues/6099
 #Style/UnneededPercentQ:  # would like to enable this one but its buggy as of 0.35.1
 #  Enabled: true
 Naming/VariableName:


### PR DESCRIPTION
autocorrect breaks things:

https://github.com/rubocop-hq/rubocop/issues/6099

