### PR TITLE
disable Bundler/DuplicatedGem

### DIFF
--- a/config/chefstyle.yml
+++ b/config/chefstyle.yml
@@ -6,7 +6,7 @@ AllCops:
 #
 
 Bundler/DuplicatedGem:
-  Enabled: true
+  Enabled: false
 
 #
 # Lint


### PR DESCRIPTION
rubocop-hq/rubocop#4432 and rubocop-hq/rubocop#3752 have been closed
against this cop which make it pretty annoying with false positives.

since this is a lint that complains against a hard-error from bundler
there really isn't a lot of point to this.  throwing a style error
to prevent a syntax error, where the linter will necessarily be
inaccurate due to static analysis is not adding value.
