### PR TITLE
disable Style/FormatStringToken

### DIFF
--- a/config/chefstyle.yml
+++ b/config/chefstyle.yml
@@ -565,3 +565,7 @@ Naming/VariableNumber:
 # This breaks all kinds of specs in chef (i don't think it will ever quite work correctly)
 Style/BracesAroundHashParameters:
   Enabled: false
+
+# We almost never use format strings but this cop triggers on any string with "%{whatever}" in it and is 99% false positives
+Style/FormatStringToken:
+  Enabled: false


### PR DESCRIPTION
- format strings are rarely used
- 99% of the alerts are false positives
- there is no autofixing cop for this one
