### PR TITLE
Bump rubocop to 0.75.1 for multiple bugfixes

### DIFF
--- a/config/disable_all.yml
+++ b/config/disable_all.yml
@@ -1,4 +1,6 @@
 ---
+Migration/DepartmentName:
+  Enabled: false
 Bundler/DuplicatedGem:
   Enabled: false
 Bundler/GemComment:
@@ -303,6 +305,8 @@ Lint/SafeNavigationWithEmpty:
   Enabled: false
 Lint/ScriptPermission:
   Enabled: false
+Lint/SendWithMixinArgument:
+  Enabled: false
 Lint/ShadowedArgument:
   Enabled: false
 Lint/ShadowedException:
@@ -465,6 +469,8 @@ Style/DocumentationMethod:
   Enabled: false
 Style/Documentation:
   Enabled: false
+Style/DoubleCopDisableDirective:
+  Enabled: false
 Style/DoubleNegation:
   Enabled: false
 Style/EachForSimpleLoop:
@@ -568,6 +574,8 @@ Style/MultilineMethodSignature:
 Style/MultilineMemoization:
   Enabled: false
 Style/MultilineTernaryOperator:
+  Enabled: false
+Style/MultilineWhenThen:
   Enabled: false
 Style/MultipleComparison:
   Enabled: false

--- a/config/upstream.yml
+++ b/config/upstream.yml
@@ -1591,6 +1591,11 @@ Lint/ScriptPermission:
   VersionAdded: '0.49'
   VersionChanged: '0.50'
 
+Lint/SendWithMixinArgument:
+  Description: 'Checks for `send` method when using mixin.'
+  Enabled: true
+  VersionAdded: '0.75'
+
 Lint/ShadowedArgument:
   Description: 'Avoid reassigning arguments before they were used.'
   Enabled: true
@@ -1662,6 +1667,7 @@ Lint/UnneededSplatExpansion:
   Description: 'Checks for splat unnecessarily being called on literals.'
   Enabled: true
   VersionAdded: '0.43'
+  VersionChanged: '0.74'
 
 Lint/UnreachableCode:
   Description: 'Unreachable code.'
@@ -1745,7 +1751,7 @@ Metrics/AbcSize:
                  branches, and conditions.
   Reference:
     - http://c2.com/cgi/wiki?AbcMetric
-    - https://en.wikipedia.org/wiki/ABC_Software_Metric'
+    - https://en.wikipedia.org/wiki/ABC_Software_Metric
   Enabled: true
   VersionAdded: '0.27'
   VersionChanged: '0.66'
@@ -1809,7 +1815,7 @@ Metrics/LineLength:
     - https
   # The IgnoreCopDirectives option causes the LineLength rule to ignore cop
   # directives like '# rubocop: enable ...' when calculating a line's length.
-  IgnoreCopDirectives: false
+  IgnoreCopDirectives: true
   # The IgnoredPatterns option is a list of !ruby/regexp and/or string
   # elements. Strings will be converted to Regexp objects. A line that matches
   # any regular expression listed in this option will be ignored by LineLength.
@@ -1847,6 +1853,14 @@ Metrics/PerceivedComplexity:
   Enabled: true
   VersionAdded: '0.25'
   Max: 7
+
+################## Migration #############################
+
+Migration/DepartmentName:
+  Description: >-
+                 Check that cop names in rubocop:disable (etc) comments are
+                 given with department name.
+  Enabled: false
 
 #################### Naming ##############################
 
@@ -1983,6 +1997,13 @@ Naming/MethodName:
   SupportedStyles:
     - snake_case
     - camelCase
+  # Method names matching patterns are always allowed.
+  #
+  #   IgnoredPatterns:
+  #     - '\A\s*onSelectionBulkChange\s*'
+  #     - '\A\s*onSelectionCleared\s*'
+  #
+  IgnoredPatterns: []
 
 Naming/PredicateName:
   Description: 'Check the names of predicate methods.'
@@ -2557,6 +2578,11 @@ Style/DocumentationMethod:
     - 'test/**/*'
   RequireForNonPublicMethods: false
 
+Style/DoubleCopDisableDirective:
+  Description: 'Checks for double rubocop:disable comments on a single line.'
+  Enabled: true
+  VersionAdded: '0.73'
+
 Style/DoubleNegation:
   Description: 'Checks for uses of double negation (!!).'
   StyleGuide: '#no-bang-bang'
@@ -2700,7 +2726,7 @@ Style/FormatStringToken:
     - template
     - unannotated
   VersionAdded: '0.49'
-  VersionChanged: '0.52'
+  VersionChanged: '0.75'
 
 Style/FrozenStringLiteralComment:
   Description: >-
@@ -2893,6 +2919,7 @@ Style/MethodCallWithArgsParentheses:
   VersionChanged: '0.61'
   IgnoreMacros: true
   IgnoredMethods: []
+  IgnoredPatterns: []
   IncludedMacros: []
   AllowParenthesesInMultilineCall: false
   AllowParenthesesInChaining: false
@@ -3042,6 +3069,12 @@ Style/MultilineTernaryOperator:
   StyleGuide: '#no-multiline-ternary'
   Enabled: true
   VersionAdded: '0.9'
+
+Style/MultilineWhenThen:
+  Description: 'Do not use then for multi-line when statement.'
+  StyleGuide: '#no-then'
+  Enabled: true
+  VersionAdded: '0.73'
 
 Style/MultipleComparison:
   Description: >-
@@ -3574,6 +3607,8 @@ Style/StringHashKeys:
   StyleGuide: '#symbols-as-keys'
   Enabled: false
   VersionAdded: '0.52'
+  VersionChanged: '0.75'
+  Safe: false
 
 Style/StringLiterals:
   Description: 'Checks if uses of quotes match the configured preference.'
@@ -3892,8 +3927,9 @@ Style/YodaCondition:
     - require_for_all_comparison_operators
     # enforce yoda only for equality operators: `!=` and `==`
     - require_for_equality_operators_only
+  Safe: false
   VersionAdded: '0.49'
-  VersionChanged: '0.63'
+  VersionChanged: '0.75'
 
 Style/ZeroLengthPredicate:
   Description: 'Use #empty? when testing for objects of length 0.'

--- a/lib/chefstyle/version.rb
+++ b/lib/chefstyle/version.rb
@@ -1,4 +1,4 @@
 module Chefstyle
   VERSION = "0.13.3".freeze
-  RUBOCOP_VERSION = "0.72.0".freeze
+  RUBOCOP_VERSION = "0.75.1".freeze
 end


### PR DESCRIPTION
This doesn't enable any new rules, but it resolves several pages of bugfixes plus a few features I wanted to get into cookstyle. Those bugfixes will probably result in new failures popping up.