### PR TITLE
Use require_relative instead of require

### DIFF
--- a/lib/chefstyle.rb
+++ b/lib/chefstyle.rb
@@ -1,4 +1,4 @@
-require "chefstyle/version"
+require_relative "chefstyle/version"
 
 # ensure the desired target version of RuboCop is gem activated
 gem "rubocop", "= #{Chefstyle::RUBOCOP_VERSION}"


### PR DESCRIPTION
Use require_relative to avoid traversing the filesystem

Signed-off-by: Tim Smith <tsmith@chef.io>