### PR TITLE
enable Lint/UriEscapeUnescape

### DIFF
--- a/config/chefstyle.yml
+++ b/config/chefstyle.yml
@@ -107,6 +107,8 @@ Lint/UnneededSplatExpansion:
   Enabled: true
 Lint/UnreachableCode:
   Enabled: true
+Lint/UriEscapeUnescape:
+  Enabled: true
 Lint/UselessAccessModifier:
   Enabled: true
 Lint/UselessAssignment:


### PR DESCRIPTION
required for ruby 2.7


https://docs.knapsackpro.com/2020/uri-escape-is-obsolete-percent-encoding-your-query-string