### PR TITLE
Stop shipping the Gemfile and Gemspec in the gem

### DIFF
--- a/chefstyle.gemspec
+++ b/chefstyle.gemspec
@@ -9,12 +9,12 @@ Gem::Specification.new do |spec|
   spec.authors       = ["Chef Software, Inc."]
   spec.email         = ["oss@chef.io"]
 
-  spec.summary       = %q{Rubocop configuration for Chef's ruby projects}
+  spec.summary       = %q{RuboCop configuration for Chef's ruby projects}
   spec.homepage      = "https://github.com/chef/chefstyle"
   spec.license       = "Apache-2.0"
   spec.required_ruby_version = ">= 2.4"
 
-  spec.files = %w{LICENSE chefstyle.gemspec Gemfile} + Dir.glob("{bin,config,lib}/**/*", File::FNM_DOTMATCH).reject { |f| File.directory?(f) }
+  spec.files = %w{LICENSE} + Dir.glob("{bin,config,lib}/**/*", File::FNM_DOTMATCH).reject { |f| File.directory?(f) }
   spec.executables = %w{chefstyle}
   spec.require_paths = ["lib"]
 


### PR DESCRIPTION
We never appbundle this app so we don't need either of these.

Signed-off-by: Tim Smith <tsmith@chef.io>