### PR TITLE
Add back the Gemspec, but remove gemfile dev groups

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,15 +2,3 @@ source "https://rubygems.org"
 
 # Specify your gem's dependencies in chefstyle.gemspec
 gemspec
-
-group :debug do
-  gem "pry"
-  gem "pry-byebug"
-  gem "pry-stack_explorer"
-end
-
-group :docs do
-  gem "github-markup"
-  gem "redcarpet"
-  gem "yard"
-end

--- a/chefstyle.gemspec
+++ b/chefstyle.gemspec
@@ -14,7 +14,7 @@ Gem::Specification.new do |spec|
   spec.license       = "Apache-2.0"
   spec.required_ruby_version = ">= 2.4"
 
-  spec.files = %w{LICENSE} + Dir.glob("{bin,config,lib}/**/*", File::FNM_DOTMATCH).reject { |f| File.directory?(f) }
+  spec.files = %w{LICENSE chefstyle.gemspec} + Dir.glob("{bin,config,lib}/**/*", File::FNM_DOTMATCH).reject { |f| File.directory?(f) }
   spec.executables = %w{chefstyle}
   spec.require_paths = ["lib"]
 


### PR DESCRIPTION
Remove unused groups, but add back the gemspec which is actually used by appbundler.