### PR TITLE
Update RuboCop to 0.83

### DIFF
--- a/config/disable_all.yml
+++ b/config/disable_all.yml
@@ -59,6 +59,8 @@ Layout/EmptyLinesAroundAccessModifier:
   Enabled: false
 Layout/EmptyLinesAroundArguments:
   Enabled: false
+Layout/EmptyLinesAroundAttributeAccessor:
+  Enabled: false
 Layout/EmptyLinesAroundBeginBody:
   Enabled: false
 Layout/EmptyLinesAroundBlockBody:
@@ -696,6 +698,8 @@ Style/SignalException:
 Style/SingleLineBlockParams:
   Enabled: false
 Style/SingleLineMethods:
+  Enabled: false
+Style/SlicingWithRange:
   Enabled: false
 Style/SpecialGlobalVars:
   Enabled: false

--- a/config/upstream.yml
+++ b/config/upstream.yml
@@ -35,6 +35,7 @@ AllCops:
     - '**/*.watchr'
     - '**/.irbrc'
     - '**/.pryrc'
+    - '**/.simplecov'
     - '**/buildfile'
     - '**/Appraisals'
     - '**/Berksfile'
@@ -53,6 +54,7 @@ AllCops:
     - '**/Podfile'
     - '**/Puppetfile'
     - '**/Rakefile'
+    - '**/rakefile'
     - '**/Snapfile'
     - '**/Steepfile'
     - '**/Thorfile'
@@ -375,6 +377,7 @@ Layout/ConditionPosition:
   StyleGuide: '#same-line-condition'
   Enabled: true
   VersionAdded: '0.53'
+  VersionChanged: '0.83'
 
 Layout/DefEndAlignment:
   Description: 'Align ends corresponding to defs correctly.'
@@ -459,6 +462,12 @@ Layout/EmptyLinesAroundArguments:
   Description: "Keeps track of empty lines around method arguments."
   Enabled: true
   VersionAdded: '0.52'
+
+Layout/EmptyLinesAroundAttributeAccessor:
+  Description: "Keep blank lines around attribute accessors."
+  StyleGuide: '#empty-lines-around-attribute-accessor'
+  Enabled: pending
+  VersionAdded: '0.83'
 
 Layout/EmptyLinesAroundBeginBody:
   Description: "Keeps track of empty lines around begin-end bodies."
@@ -1295,8 +1304,8 @@ Layout/TrailingWhitespace:
   StyleGuide: '#no-trailing-whitespace'
   Enabled: true
   VersionAdded: '0.49'
-  VersionChanged: '0.55'
-  AllowInHeredoc: false
+  VersionChanged: '0.83'
+  AllowInHeredoc: true
 
 #################### Lint ##################################
 ### Warnings
@@ -1316,6 +1325,7 @@ Lint/AmbiguousOperator:
   StyleGuide: '#method-invocation-parens'
   Enabled: true
   VersionAdded: '0.17'
+  VersionChanged: '0.83'
 
 Lint/AmbiguousRegexpLiteral:
   Description: >-
@@ -1323,6 +1333,7 @@ Lint/AmbiguousRegexpLiteral:
                  a method invocation without parentheses.
   Enabled: true
   VersionAdded: '0.17'
+  VersionChanged: '0.83'
 
 Lint/AssignmentInCondition:
   Description: "Don't use assignment in conditions."
@@ -1339,8 +1350,9 @@ Lint/BigDecimalNew:
 Lint/BooleanSymbol:
   Description: 'Check for `:true` and `:false` symbols.'
   Enabled: true
+  Safe: false
   VersionAdded: '0.50'
-  VersionChanged: '0.81'
+  VersionChanged: '0.83'
 
 Lint/CircularArgumentReference:
   Description: "Default values in optional keyword arguments and optional ordinal arguments should not refer back to the name of the argument."
@@ -1411,13 +1423,16 @@ Lint/EmptyInterpolation:
 Lint/EmptyWhen:
   Description: 'Checks for `when` branches with empty bodies.'
   Enabled: true
+  AllowComments: true
   VersionAdded: '0.45'
+  VersionChanged: '0.83'
 
 Lint/EnsureReturn:
   Description: 'Do not use return in an ensure block.'
   StyleGuide: '#no-return-ensure'
   Enabled: true
   VersionAdded: '0.9'
+  VersionChanged: '0.83'
 
 Lint/ErbNewArguments:
   Description: 'Use `:trim_mode` and `:eoutvar` keyword arguments to `ERB.new`.'
@@ -1565,6 +1580,7 @@ Lint/ParenthesesAsGroupedExpression:
   StyleGuide: '#parens-no-spaces'
   Enabled: true
   VersionAdded: '0.12'
+  VersionChanged: '0.83'
 
 Lint/PercentStringArray:
   Description: >-
@@ -1808,7 +1824,7 @@ Lint/UselessAccessModifier:
   Description: 'Checks for useless access modifiers.'
   Enabled: true
   VersionAdded: '0.20'
-  VersionChanged: '0.47'
+  VersionChanged: '0.83'
   ContextCreatingMethods: []
   MethodCreatingMethods: []
 
@@ -2948,6 +2964,7 @@ Style/IfWithSemicolon:
   StyleGuide: '#no-semicolon-ifs'
   Enabled: true
   VersionAdded: '0.9'
+  VersionChanged: '0.83'
 
 Style/ImplicitRuntimeError:
   Description: >-
@@ -3425,7 +3442,9 @@ Style/OptionalArguments:
                  of the argument list.
   StyleGuide: '#optional-arguments'
   Enabled: true
+  Safe: false
   VersionAdded: '0.33'
+  VersionChanged: '0.83'
 
 Style/OrAssignment:
   Description: 'Recommend usage of double pipe equals (||=) where applicable.'
@@ -3729,6 +3748,12 @@ Style/SingleLineMethods:
   VersionAdded: '0.9'
   VersionChanged: '0.19'
   AllowIfMethodIsEmpty: true
+
+Style/SlicingWithRange:
+  Description: 'Checks array slicing is done with endless ranges when suitable.'
+  Enabled: pending
+  VersionAdded: '0.83'
+  Safe: false
 
 Style/SpecialGlobalVars:
   Description: 'Avoid Perl-style global variables.'

--- a/lib/chefstyle/version.rb
+++ b/lib/chefstyle/version.rb
@@ -1,4 +1,4 @@
 module Chefstyle
   VERSION = "1.0.4".freeze
-  RUBOCOP_VERSION = "0.82.0".freeze
+  RUBOCOP_VERSION = "0.83.0".freeze
 end


### PR DESCRIPTION
Fixes a giant pile of bugs including a few that impacted cookbooks
Adds autocorrection to a few cops including the issues with ambiguous operators that was painful in cookbooks

Signed-off-by: Tim Smith <tsmith@chef.io>