### PR TITLE
Require RuboCop 0.85.1

### DIFF
--- a/lib/chefstyle/version.rb
+++ b/lib/chefstyle/version.rb
@@ -1,4 +1,4 @@
 module Chefstyle
   VERSION = "1.1.0".freeze
-  RUBOCOP_VERSION = "0.85.0".freeze
+  RUBOCOP_VERSION = "0.85.1".freeze
 end


### PR DESCRIPTION
This includes a few useful bug fixes, but no config changes so there's
no need to vendor

Signed-off-by: Tim Smith <tsmith@chef.io>