### PR TITLE
Enable Style/Encoding cop

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,0 +1,2 @@
+Style/FrozenStringLiteralComment:
+  Enabled: true

--- a/Gemfile
+++ b/Gemfile
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 source "https://rubygems.org"
 
 # Specify your gem's dependencies in chefstyle.gemspec

--- a/Rakefile
+++ b/Rakefile
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require "bundler/gem_tasks"
 
 upstream = Gem::Specification.find_by_name("rubocop")

--- a/bin/chefstyle
+++ b/bin/chefstyle
@@ -1,6 +1,5 @@
 #!/usr/bin/env ruby
-# -*- encoding: utf-8 -*-
-
+# frozen_string_literal: true
 $LOAD_PATH.unshift File.join(File.dirname(__FILE__), %w{.. lib})
 
 require "chefstyle"

--- a/chefstyle.gemspec
+++ b/chefstyle.gemspec
@@ -1,4 +1,4 @@
-# coding: utf-8
+# frozen_string_literal: true
 lib = File.expand_path("../lib", __FILE__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 require "chefstyle/version"

--- a/config/chefstyle.yml
+++ b/config/chefstyle.yml
@@ -482,11 +482,15 @@ Style/WhileUntilModifier:
 Style/WordArray:
   Enabled: true
 
+# we are ruby > 2.0 only so we can remove encoding comments for utf-8
+Style/Encoding:
+  Enabled: true
+
 #
 # Disabled Style
 #
 
-# FIXME: we need to enable this
+# reduces memory usage, but isn't a simple autocorrect so we need to do this one project at a time
 Style/FrozenStringLiteralComment:
   Enabled: false
 
@@ -527,10 +531,6 @@ Style/FormatString:
   Enabled: false
 # single line if/unless blocks may read more naturally than modifiers
 Style/IfUnlessModifier:
-  Enabled: false
-
-# we are ruby > 2.0 only so can disable the Encoding cop
-Style/Encoding:
   Enabled: false
 
 # Dan is -1 on this one: https://github.com/chef/chef/pull/4526#issuecomment-179950045

--- a/lib/chefstyle.rb
+++ b/lib/chefstyle.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require_relative "chefstyle/version"
 
 # ensure the desired target version of RuboCop is gem activated

--- a/lib/chefstyle/version.rb
+++ b/lib/chefstyle/version.rb
@@ -1,4 +1,5 @@
+# frozen_string_literal: true
 module Chefstyle
-  VERSION = "1.1.3".freeze
-  RUBOCOP_VERSION = "0.87.1".freeze
+  VERSION = "1.1.3"
+  RUBOCOP_VERSION = "0.87.1"
 end


### PR DESCRIPTION
The encoding cop was previously disabled as it *added* the encoding comments. Now it removes them if they were setting utf-8 since that's the default on Ruby 2 and is totally pointless to set.

This also enables the frozen string literal comment cop for this repo so we can start the process of getting ready to enable that.

Signed-off-by: Tim Smith <tsmith@chef.io>