### PR TITLE
Enable Lint/Syntax

### DIFF
--- a/config/chefstyle.yml
+++ b/config/chefstyle.yml
@@ -633,6 +633,10 @@ Style/CommentedKeyword:
 Lint/DeprecatedOpenSSLConstant:
   Enabled: true
 
+# alert on invalid ruby synatx
+Lint/Syntax:
+  Enabled: true
+
 ChefRuby/Ruby27KeywordArgumentWarnings:
   Description: Pass options to shell_out helpers without the brackets to avoid Ruby 2.7 deprecation warnings.
   Enabled: true


### PR DESCRIPTION
Something inside rubocop enabled this rule previously even though we've
had it disabled the whole time.

Signed-off-by: Tim Smith <tsmith@chef.io>