### PR TITLE
Allow 1 line defs w/o a space between

### DIFF
--- a/config/chefstyle.yml
+++ b/config/chefstyle.yml
@@ -243,6 +243,7 @@ Layout/EmptyLineAfterGuardClause:
   Enabled: true
 Layout/EmptyLineBetweenDefs:
   Enabled: true
+  AllowAdjacentOneLineDefs: true
 Layout/EmptyLines:
   Enabled: true
 Layout/EmptyLinesAroundAccessModifier:


### PR DESCRIPTION
This is a common thing with empty class defs

Signed-off-by: Tim Smith <tsmith@chef.io>