### PR TITLE
Update to RuboCop 1.13 and remove Ruby 2.4 support

### DIFF
--- a/.expeditor/verify.pipeline.yml
+++ b/.expeditor/verify.pipeline.yml
@@ -11,14 +11,6 @@ expeditor:
 
 steps:
 
-- label: run-chefstyle-and-specs-ruby-2.4
-  command:
-    - .expeditor/run_linux_tests.sh rake
-  expeditor:
-    executor:
-      docker:
-        image: ruby:2.4-buster
-
 - label: run-chefstyle-and-specs-ruby-2.5
   command:
     - .expeditor/run_linux_tests.sh rake

--- a/config/chefstyle.yml
+++ b/config/chefstyle.yml
@@ -1,5 +1,5 @@
 AllCops:
-  TargetRubyVersion: 2.4
+  TargetRubyVersion: 2.5
   SuggestExtensions: false
 
 #

--- a/config/disable_all.yml
+++ b/config/disable_all.yml
@@ -147,6 +147,8 @@ Layout/MultilineOperationIndentation:
   Enabled: false
 Layout/ParameterAlignment:
   Enabled: false
+Layout/RedundantLineBreak:
+  Enabled: false
 Layout/RescueEnsureAlignment:
   Enabled: false
 Layout/SpaceAfterColon:

--- a/config/upstream.yml
+++ b/config/upstream.yml
@@ -1101,6 +1101,14 @@ Layout/ParameterAlignment:
   # But it can be overridden by setting this parameter
   IndentationWidth: ~
 
+Layout/RedundantLineBreak:
+  Description: >-
+                 Do not break up an expression into multiple lines when it fits
+                 on a single line.
+  Enabled: false
+  InspectBlocks: false
+  VersionAdded: '1.13'
+
 Layout/RescueEnsureAlignment:
   Description: 'Align rescues and ensures correctly.'
   Enabled: true
@@ -1380,6 +1388,8 @@ Lint/AmbiguousBlockAssociation:
   StyleGuide: '#syntax'
   Enabled: true
   VersionAdded: '0.48'
+  VersionChanged: '1.13'
+  IgnoredMethods: []
 
 Lint/AmbiguousOperator:
   Description: >-

--- a/lib/chefstyle/version.rb
+++ b/lib/chefstyle/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 module Chefstyle
   VERSION = "1.7.5"
-  RUBOCOP_VERSION = "1.12.1"
+  RUBOCOP_VERSION = "1.13.0"
 end


### PR DESCRIPTION
This release removes support for Ruby 2.4