### PR TITLE
Exclude the vendor dir in our default config

### DIFF
--- a/config/chefstyle.yml
+++ b/config/chefstyle.yml
@@ -1,6 +1,8 @@
 AllCops:
   TargetRubyVersion: 2.5
   SuggestExtensions: false
+  Exclude:
+  - vendor/**/*.rb # we don't want to scan anything in a vendor dir
 
 #
 # Bundler


### PR DESCRIPTION
This was suggested here: https://github.com/rubocop/rubocop/issues/9832

Signed-off-by: Tim Smith <tsmith@chef.io>