### PR TITLE
[Chefstyle] Mark Chefstyle repository as deprecated

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,11 +4,11 @@
 
 **Umbrella Project**: [Chef Foundation](https://github.com/chef/chef-oss-practices/blob/main/projects/chef-foundation.md)
 
-**Project State**: [Active](https://github.com/chef/chef-oss-practices/blob/main/repo-management/repo-states.md#active)
+**Project State**: [Deprecated](https://github.com/chef/chef-oss-practices/blob/main/repo-management/repo-states.md#deprecated)
 
-**Issues [Response Time Maximum](https://github.com/chef/chef-oss-practices/blob/main/repo-management/repo-states.md)**: 14 days
-
-**Pull Request [Response Time Maximum](https://github.com/chef/chef-oss-practices/blob/main/repo-management/repo-states.md)**: 14 days
+This project has been merged into
+[Cookstyle](https://github.com/chef/cookstyle) as of Cookstyle 7.32.7, where it
+can be triggered by running `cookstyle --chefstyle`.
 
 This is an internal style guide for chef ruby projects (chef-client,
 ohai, mixlib-shellout, mixlib-config, etc).


### PR DESCRIPTION
## Description

[Chefstyle was merged into Cookstyle](https://github.com/chef/cookstyle/pull/968), and so there's no longer a reason to keep a separate repository. Any future fixes to the Chefstyle configuration should be handled in the Cookstyle repository.

Once all the Chef github org repositories and [major reverse dependencies on the gem](https://rubygems.org/gems/chefstyle/reverse_dependencies) are addressed, it can be sent to chef-boneyard.

<!--- Provide a short summary of your changes in the Title above -->

<!--- Describe your changes in detail, what problems does it solve? -->

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [x] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] If `Gemfile.lock` has changed, I have used `--conservative` to do it and included the full output in the Description above.
- [ ] All new and existing tests passed.
- [x] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
